### PR TITLE
Fix null emails and backup matching

### DIFF
--- a/app/database.py
+++ b/app/database.py
@@ -61,10 +61,6 @@ class Database:
 
         cur = self.conn.cursor()
         for participant in participants:
-
-            if participant.email == None:
-                participant.email = "NULL"
-
             cur.execute("INSERT INTO app.participant (group_id, participant_id, participant_name, participant_email, recipient_id) VALUES (%s, %s, %s, %s, %s);", (group_id, participant.participant_id, participant.name, participant.email, matches[participant].participant_id))
 
             for restriction in participant.restrictions:
@@ -278,9 +274,9 @@ class Database:
         """Get all emails for participants in a group."""
 
         cur = self.conn.cursor()
-        cur.execute("SELECT participant_name, participant_email, recipient_id FROM app.participant WHERE group_id=%s;", (group_id,))
+        cur.execute("SELECT participant_name, participant_email, recipient_id FROM app.participant WHERE group_id=%s AND participant_email IS NOT NULL;", (group_id,))
         participants = cur.fetchall()
-
+        
         participants_output = []
         for participant_name, participant_email, recipient_id in participants:
             cur.execute("SELECT participant_name FROM app.participant WHERE group_id=%s AND participant_id=%s LIMIT 1;", (group_id, recipient_id))

--- a/app/group.py
+++ b/app/group.py
@@ -31,7 +31,7 @@ def create_group():
             return display_status("Participant HTML message is too long (2000 character limit).")
 
         participants = secret_santa.get_participants(request.form)
-
+        
         # cannot match with only two people
         if len(participants) <= 2:
             return display_status("Not enough participants to match.")
@@ -112,7 +112,7 @@ def display_group(group_id):
             text_message, html_message = db.get_group_messages(group_id)
             
             participant_email_matches = db.get_participant_email_matches(group_id)
-            
+
             secret_santa.send_emails(participant_email_matches, text_message, html_message)
             db.group_sent_emails(group_id)
 

--- a/app/utils/secret_santa.py
+++ b/app/utils/secret_santa.py
@@ -35,12 +35,15 @@ def match_people(start_people):
             potential_match.name not in person.restrictions and
             matches.get(potential_match) != person):
                 matches[person] = potential_match
-
                 potential_matches.pop(i)
                 break
             
             # person could not be matched
             if i == len(potential_matches) - 1:
+                # already gone through everything and matches is empty
+                if not matches:
+                    return None
+
                 # attempt to replace from an earlier match
                 for i, (gifter, recipient) in enumerate(matches.items()):
                     if (person != recipient and
@@ -64,9 +67,6 @@ def send_emails(matches, message_text, message_html):
     server.login(SENDER_EMAIL, APP_PASSWORD)
     
     for gifter, recipient_name in matches:
-        if gifter[1] == None:
-            continue
-
         msg = MIMEMultipart("alternative")
         msg["Subject"] = "Secret Santa"
         msg["From"] = f"Secret Santa Organizer <{SENDER_EMAIL}>"


### PR DESCRIPTION
Emails were being stored as "NULL" instead of NULL.
An impossible match was not returning None if the person was the first because of the empty dictionary. 